### PR TITLE
Update to nom v8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 publish = true
 
 [dependencies]
-nom = "7.1.3"
+nom = "8"
 thiserror = { version = "2.0.9", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ publish = true
 
 [dependencies]
 nom = "7.1.3"
-nom-derive = "0.10.1"
 thiserror = { version = "2.0.9", default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,5 +32,3 @@ mod types;
 
 pub use error::Error;
 pub use types::*;
-
-pub use nom_derive::Parse;

--- a/src/types/class_id.rs
+++ b/src/types/class_id.rs
@@ -1,5 +1,10 @@
+use nom::{
+    number::streaming::{be_u16, be_u32},
+    IResult,
+};
+
 /// Class Identifier
-#[derive(Clone, Copy, Debug, Eq, PartialEq, nom_derive::NomBE)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClassId {
     /// Organizationally Unique Identifier assigned by IEEE, VITA, the VRT Profile author, or a reserved OUI.
     pub oui: u32,
@@ -7,4 +12,22 @@ pub struct ClassId {
     pub packet_class_code: u16,
     /// Information Class Code
     pub information_class_code: u16,
+}
+
+impl ClassId {
+    /// Parse the Class ID
+    pub fn parse(i: &[u8]) -> IResult<&[u8], ClassId> {
+        let (i, oui) = be_u32(i)?;
+        let (i, packet_class_code) = be_u16(i)?;
+        let (i, information_class_code) = be_u16(i)?;
+
+        Ok((
+            i,
+            ClassId {
+                oui,
+                packet_class_code,
+                information_class_code,
+            },
+        ))
+    }
 }

--- a/src/types/header.rs
+++ b/src/types/header.rs
@@ -29,7 +29,7 @@ impl Header {
         }
 
         let (i, first_byte) = be_u8(i)?;
-        let packet_type = PktType::try_from(first_byte >> 4 & 0b1111)
+        let packet_type = PktType::try_from((first_byte >> 4) & 0b1111)
             .map_err(|_| Err::Error(nom::error::Error::new(i, nom::error::ErrorKind::Verify)))?;
         let c = ((first_byte >> 3) & 0x01) != 0;
         let t = ((first_byte >> 2) & 0x01) != 0;

--- a/src/types/packet.rs
+++ b/src/types/packet.rs
@@ -2,7 +2,6 @@ use nom::{
     number::streaming::{be_u32, be_u64},
     Err, IResult, Needed,
 };
-use nom_derive::Parse;
 
 use super::*;
 


### PR DESCRIPTION
- Update to nom v8.0
- Remove nom-derive
   - Incompatible with nom v8.0
   - Hasn't been updated in years